### PR TITLE
Improve landing page and share poem index loader

### DIFF
--- a/src/site/assets/poem-index.js
+++ b/src/site/assets/poem-index.js
@@ -1,0 +1,152 @@
+const LINK_RE = /\[\[([^\]|#]+?)(?:\|([^\]]+))?\]\]/g;
+
+function buildItems(markdown) {
+  const items = [];
+  if (!markdown) {
+    return items;
+  }
+
+  let match;
+  while ((match = LINK_RE.exec(markdown)) !== null) {
+    const rawTarget = (match[1] || '').trim();
+    if (!rawTarget) continue;
+    const label = (match[2] || rawTarget).trim();
+    const baseName = rawTarget.replace(/\.md$/i, '');
+    const fileName = `${baseName}.md`;
+    items.push({ label, fileName });
+  }
+  return items;
+}
+
+function normalizeBase(base) {
+  if (!base) return '';
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+function clearList(listEl) {
+  while (listEl.firstChild) {
+    listEl.removeChild(listEl.firstChild);
+  }
+}
+
+export function initPoemIndex(options = {}) {
+  const {
+    listSelector = '#poem-list',
+    statusSelector = '#status',
+    hintSelector = '#hint',
+    indexPath = 'index.md',
+    viewerBase = 'viewer.html',
+    fileBase = '',
+    limit = null,
+    fallbackMarkdown = null,
+  } = options;
+
+  const listEl = document.querySelector(listSelector);
+  if (!listEl) {
+    console.warn(`initPoemIndex: no encontré el elemento '${listSelector}'.`);
+    return;
+  }
+
+  const statusEl = statusSelector ? document.querySelector(statusSelector) : null;
+  const hintEl = hintSelector ? document.querySelector(hintSelector) : null;
+
+  const setStatus = (text) => {
+    if (statusEl) {
+      statusEl.textContent = text;
+    }
+  };
+
+  const setHintVisible = (visible) => {
+    if (hintEl) {
+      hintEl.hidden = !visible;
+    }
+  };
+
+  const fileBasePath = normalizeBase(fileBase);
+  const limited = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : null;
+
+  const renderItems = (items) => {
+    clearList(listEl);
+
+    if (!items.length) {
+      setStatus('No hay poemas listados en index.md.');
+      return;
+    }
+
+    const visibleItems = limited ? items.slice(0, limited) : items;
+    setStatus('Lista preparada.');
+    setHintVisible(false);
+
+    visibleItems.forEach(({ label, fileName }) => {
+      const li = document.createElement('li');
+      const link = document.createElement('a');
+      const encoded = encodeURIComponent(fileName);
+      link.href = `${viewerBase}?file=${encoded}`;
+      link.textContent = label;
+      li.appendChild(link);
+      listEl.appendChild(li);
+
+      fetch(`${fileBasePath}${encoded}`, { method: 'HEAD' })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('missing');
+          }
+        })
+        .catch(() => {
+          li.classList.add('missing');
+          link.removeAttribute('href');
+          const warning = document.createElement('span');
+          warning.textContent = '(archivo faltante)';
+          li.appendChild(warning);
+          setHintVisible(true);
+          setStatus('Hay poemas pendientes por subir.');
+        });
+    });
+
+    if (limited && items.length > visibleItems.length) {
+      const moreLi = document.createElement('li');
+      moreLi.classList.add('more-items', 'muted');
+      const remaining = items.length - visibleItems.length;
+      moreLi.textContent = `… y ${remaining} poema${remaining === 1 ? '' : 's'} más en el índice completo.`;
+      listEl.appendChild(moreLi);
+    }
+  };
+
+  const renderFromMarkdown = (markdown) => {
+    const items = buildItems(markdown);
+    renderItems(items);
+    return items.length;
+  };
+
+  if (fallbackMarkdown) {
+    try {
+      const count = renderFromMarkdown(fallbackMarkdown);
+      if (count) {
+        setStatus('Lista precargada. Verificando actualizaciones…');
+      }
+    } catch (error) {
+      console.error('No se pudo renderizar el índice precargado:', error);
+    }
+  }
+
+  fetch(indexPath)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`No se pudo cargar index.md (HTTP ${response.status})`);
+      }
+      return response.text();
+    })
+    .then((markdown) => {
+      renderFromMarkdown(markdown);
+    })
+    .catch((error) => {
+      console.error(error);
+      if (!listEl.childElementCount) {
+        setStatus('No se pudo preparar el índice.');
+      } else {
+        setStatus('Mostrando la copia precargada del índice.');
+      }
+    });
+}
+
+export default initPoemIndex;

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,5 +1,148 @@
 <!doctype html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Takumi’s Garden</title>
-<h1>Takumi’s Garden</h1>
-<p><a href="notes/Escritos/Canciones-poemas-escritos/">Entrar: Canciones, poemas y escritos</a></p>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+<style>
+  :root {
+    color-scheme: light dark;
+  }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+  }
+
+  main.container {
+    padding-block: 3.5rem 4.5rem;
+    max-width: 62rem;
+  }
+
+  .hero {
+    text-align: center;
+    margin-bottom: 3.5rem;
+  }
+
+  .hero p {
+    font-size: 1.1rem;
+    margin-inline: auto;
+    max-width: 42rem;
+  }
+
+  .hero .actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-top: 2rem;
+  }
+
+  .hero .actions a[role="button"] {
+    min-width: 13rem;
+  }
+
+  section.poem-index {
+    margin-top: 1rem;
+  }
+
+  section.poem-index h2 {
+    margin-bottom: 0.5rem;
+  }
+
+  #status-root {
+    color: var(--muted-color, #666);
+  }
+
+  ul#poem-list-root {
+    list-style: none;
+    padding: 0;
+    margin: 2rem 0;
+    columns: 1;
+    column-gap: 2.5rem;
+  }
+
+  @media (min-width: 56rem) {
+    ul#poem-list-root {
+      columns: 2;
+    }
+  }
+
+  ul#poem-list-root li {
+    break-inside: avoid;
+    margin-bottom: 0.4rem;
+  }
+
+  ul#poem-list-root li a {
+    text-decoration: none;
+  }
+
+  ul#poem-list-root li a:hover {
+    text-decoration: underline;
+  }
+
+  ul#poem-list-root li.missing {
+    color: var(--del-color, #c02c2c);
+  }
+
+  ul#poem-list-root li.missing span {
+    font-size: 0.9em;
+    margin-left: 0.35rem;
+    color: inherit;
+  }
+
+  ul#poem-list-root li.more-items {
+    margin-top: 0.75rem;
+  }
+
+  footer {
+    margin-top: 4rem;
+    text-align: center;
+    color: var(--muted-color, #666);
+  }
+</style>
+<main class="container">
+  <section class="hero">
+    <h1>Takumi’s Garden</h1>
+    <p>
+      Canciones, poemas y escritos seleccionados. Explora el índice completo con el visor de
+      Pico CSS para leer cada pieza en modo claro u oscuro según tu dispositivo.
+    </p>
+    <div class="actions">
+      <a href="notes/Escritos/Canciones-poemas-escritos/viewer.html" role="button" class="contrast">Abrir el visor</a>
+      <a href="notes/Escritos/Canciones-poemas-escritos/" role="button" class="secondary">Ver índice completo</a>
+    </div>
+  </section>
+
+  <section class="poem-index" aria-labelledby="poem-index-heading">
+    <h2 id="poem-index-heading">Poemas publicados</h2>
+    <p id="status-root" role="status">Cargando poemas…</p>
+    <ul id="poem-list-root"></ul>
+    <p class="muted" id="hint-root" hidden>
+      Algunos enlaces aparecen sin archivo porque falta el <code>.md</code> correspondiente.
+      Guárdalo dentro de <code>notes/Escritos/Canciones-poemas-escritos/</code> y vuelve a publicar.
+    </p>
+    <p class="muted">¿Buscas un título en particular? Abre el índice completo para verlo todo.</p>
+  </section>
+
+  <footer>
+    <p>Actualizado automáticamente a partir de los archivos Markdown del repositorio.</p>
+  </footer>
+</main>
+<noscript>
+  <p role="alert" class="container">Activa JavaScript para generar la lista de poemas.</p>
+</noscript>
+<script type="module">
+  import initPoemIndex from "./assets/poem-index.js";
+
+  initPoemIndex({
+    listSelector: '#poem-list-root',
+    statusSelector: '#status-root',
+    hintSelector: '#hint-root',
+    indexPath: 'notes/Escritos/Canciones-poemas-escritos/index.md',
+    viewerBase: 'notes/Escritos/Canciones-poemas-escritos/viewer.html',
+    fileBase: 'notes/Escritos/Canciones-poemas-escritos',
+    limit: 24,
+  });
+</script>

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
@@ -1,83 +1,69 @@
 <!doctype html>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Canciones, poemas y escritos</title>
-<h1>Canciones, poemas y escritos</h1>
-<ul>
-  <li><a href="viewer.html?file=Amigos.md">Amigos</a></li>
-  <li><a href="viewer.html?file=A%20nadie%2C%20nunca.md">A nadie, nunca</a></li>
-  <li><a href="viewer.html?file=Miradas.md">Miradas</a></li>
-  <li><a href="viewer.html?file=Listas.md">Listas</a></li>
-  <li><a href="viewer.html?file=Siempre.md">Siempre</a></li>
-  <li><a href="viewer.html?file=Notificaciones.md">Notificaciones</a></li>
-  <li><a href="viewer.html?file=Inconsciente.md">Inconsciente</a></li>
-  <li><a href="viewer.html?file=Escribo.md">Escribo</a></li>
-  <li><a href="viewer.html?file=Falta.md">Falta</a></li>
-  <li><a href="viewer.html?file=Hospital.md">Hospital</a></li>
-  <li><a href="viewer.html?file=Why%20is%20it%20like%20this.md">Why is it like this</a></li>
-  <li><a href="viewer.html?file=Creencias.md">Creencias</a></li>
-  <li><a href="viewer.html?file=Sound.md">Sound</a></li>
-  <li><a href="viewer.html?file=Kintsugi.md">Kintsugi</a></li>
-  <li><a href="viewer.html?file=Ganas.md">Ganas</a></li>
-  <li><a href="viewer.html?file=Este%20chico.md">Este chico</a></li>
-  <li><a href="viewer.html?file=Magnifico.md">Magnifico</a></li>
-  <li><a href="viewer.html?file=No%20estoy%20a%20la%20altura.md">No estoy a la altura</a></li>
-  <li><a href="viewer.html?file=Scars.md">Scars</a></li>
-  <li><a href="viewer.html?file=Body.md">Body</a></li>
-  <li><a href="viewer.html?file=My%20big%20dream.md">My big dream</a></li>
-  <li><a href="viewer.html?file=Delirios%20en%20la%20ducha.md">Delirios en la ducha</a></li>
-  <li><a href="viewer.html?file=Pastis.md">Pastis</a></li>
-  <li><a href="viewer.html?file=Basura.md">Basura</a></li>
-  <li><a href="viewer.html?file=Escenarios.md">Escenarios</a></li>
-  <li><a href="viewer.html?file=Eli%20x2.md">Eli x2</a></li>
-  <li><a href="viewer.html?file=Delgado.md">Delgado</a></li>
-  <li><a href="viewer.html?file=Porro.md">Porro</a></li>
-  <li><a href="viewer.html?file=Me%20ha%20dado%20miedo.md">Me ha dado miedo</a></li>
-  <li><a href="viewer.html?file=Repito.md">Repito</a></li>
-  <li><a href="viewer.html?file=No%20es%20justo.md">No es justo</a></li>
-  <li><a href="viewer.html?file=In%20the%20neck.md">In the neck</a></li>
-  <li><a href="viewer.html?file=Indicaciones.md">Indicaciones</a></li>
-  <li><a href="viewer.html?file=Alcohol.md">Alcohol</a></li>
-  <li><a href="viewer.html?file=Sombras.md">Sombras</a></li>
-  <li><a href="viewer.html?file=Aphantasia.md">Aphantasia</a></li>
-  <li><a href="viewer.html?file=%C2%BFPara%20que.md">¿Para que</a></li>
-  <li><a href="viewer.html?file=Duele.md">Duele</a></li>
-  <li><a href="viewer.html?file=Envejecer.md">Envejecer</a></li>
-  <li><a href="viewer.html?file=Same%20thing.md">Same thing</a></li>
-  <li><a href="viewer.html?file=Abuelo.md">Abuelo</a></li>
-  <li><a href="viewer.html?file=No%20entiendo.md">No entiendo</a></li>
-  <li><a href="viewer.html?file=Terapeuta%20virtual.md">Terapeuta virtual</a></li>
-  <li><a href="viewer.html?file=Perdido.md">Perdido</a></li>
-  <li><a href="viewer.html?file=Alone.md">Alone</a></li>
-  <li><a href="viewer.html?file=El%20lastimado.md">El lastimado</a></li>
-  <li><a href="viewer.html?file=Mi%20cerebro.md">Mi cerebro</a></li>
-  <li><a href="viewer.html?file=Afilado.md">Afilado</a></li>
-  <li><a href="viewer.html?file=Me%20volvieron%20a%20dejar.md">Me volvieron a dejar</a></li>
-  <li><a href="viewer.html?file=Random%20vent.md">Random vent</a></li>
-  <li><a href="viewer.html?file=Llanto.md">Llanto</a></li>
-  <li><a href="viewer.html?file=Vacio.md">Vacio</a></li>
-  <li><a href="viewer.html?file=SHP.com.md">SHP.com</a></li>
-  <li><a href="viewer.html?file=Casi%20lo%20hago.md">Casi lo hago</a></li>
-  <li><a href="viewer.html?file=Cronico.md">Cronico</a></li>
-  <li><a href="viewer.html?file=En%20que%20piensas.md">En que piensas</a></li>
-  <li><a href="viewer.html?file=Todo.md">Todo</a></li>
-  <li><a href="viewer.html?file=Disposable.md">Disposable</a></li>
-  <li><a href="viewer.html?file=Calladito.md">Calladito</a></li>
-  <li><a href="viewer.html?file=Todo%20mal.md">Todo mal</a></li>
-  <li><a href="viewer.html?file=Borroso.md">Borroso</a></li>
-  <li><a href="viewer.html?file=Waking%20up%20or%20falling%20down.md">Waking up or falling down</a></li>
-  <li><a href="viewer.html?file=Escapulas.md">Escapulas</a></li>
-  <li><a href="viewer.html?file=En%20la%20sien.md">En la sien</a></li>
-  <li><a href="viewer.html?file=3%20en%20ralla.md">3 en ralla</a></li>
-  <li><a href="viewer.html?file=Tik%20tok%20curse.md">Tik tok curse</a></li>
-  <li><a href="viewer.html?file=Creo%20que%20tengo%20tlp.md">Creo que tengo tlp</a></li>
-  <li><a href="viewer.html?file=Mala%20hija.md">Mala hija</a></li>
-  <li><a href="viewer.html?file=Padres.md">Padres</a></li>
-  <li><a href="viewer.html?file=Las%20veces%20que%20he%20despertado.md">Las veces que he despertado</a></li>
-  <li><a href="viewer.html?file=Slit.md">Slit</a></li>
-  <li><a href="viewer.html?file=Irrealidad.md">Irrealidad</a></li>
-  <li><a href="viewer.html?file=Redentor%20en%20ruinas.md">Redentor en ruinas</a></li>
-  <li><a href="viewer.html?file=Mi%20deseo.md">Mi deseo</a></li>
-  <li><a href="viewer.html?file=TEA.md">TEA</a></li>
-  <li><a href="viewer.html?file=Seen.md">Seen</a></li>
-  <li><a href="viewer.html?file=Sex.md">Sex</a></li>
-</ul>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+<style>
+  body { margin: 0; }
+  main.container {
+    padding-block: 3rem;
+    max-width: 60rem;
+  }
+  #status {
+    color: var(--muted-color, #666);
+  }
+  ul#poem-list {
+    list-style: none;
+    padding: 0;
+    margin: 2rem 0;
+    columns: 1;
+    column-gap: 2.5rem;
+  }
+  @media (min-width: 56rem) {
+    ul#poem-list {
+      columns: 2;
+    }
+  }
+  ul#poem-list li {
+    break-inside: avoid;
+    margin-bottom: .35rem;
+  }
+  ul#poem-list li a {
+    text-decoration: none;
+  }
+  ul#poem-list li a:hover {
+    text-decoration: underline;
+  }
+  ul#poem-list li.missing {
+    color: var(--del-color, #c02c2c);
+  }
+  ul#poem-list li.missing span {
+    font-size: .9em;
+    margin-left: .35rem;
+    color: inherit;
+  }
+</style>
+<main class="container">
+  <h1>Canciones, poemas y escritos</h1>
+  <p>Selecciona un poema para abrirlo en el visor con el nuevo tema claro/oscuro.</p>
+  <p id="status" role="status">Cargando poemas…</p>
+  <ul id="poem-list"></ul>
+  <p class="muted" id="hint" hidden>
+    Algunos enlaces aparecen sin archivo porque todavía no existe el <code>.md</code> correspondiente. Asegúrate de guardarlo dentro de esta carpeta y volver a publicar.
+  </p>
+</main>
+<noscript>
+  <p role="alert" class="container">Activa JavaScript para ver la lista completa de poemas.</p>
+</noscript>
+<script type="module">
+  import initPoemIndex from "../../assets/poem-index.js";
+
+  initPoemIndex({
+    listSelector: '#poem-list',
+    statusSelector: '#status',
+    hintSelector: '#hint',
+    indexPath: 'index.md',
+    viewerBase: 'viewer.html',
+    fileBase: '',
+  });
+</script>


### PR DESCRIPTION
## Summary
- add a reusable ES module that builds the poem index from `index.md` and flags missing markdown files
- update the poem index page to use the shared loader and include a `<noscript>` fallback message
- restyle the site homepage with Pico CSS and show a dynamic preview of the poems list using the same loader

## Testing
- not run (static site change)

------
https://chatgpt.com/codex/tasks/task_e_68d40bc2fd8c832387e3378a1e1b2ee5