### PR TITLE
Fix poem index detection for older browsers

### DIFF
--- a/src/site/assets/poem-index.js
+++ b/src/site/assets/poem-index.js
@@ -64,7 +64,10 @@ export function initPoemIndex(options = {}) {
 
   const fileBasePath = normalizeBase(fileBase);
   const limited = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : null;
-  const isFileProtocol = typeof window !== 'undefined' && window.location?.protocol === 'file:';
+  const isFileProtocol =
+    typeof window !== 'undefined' &&
+    window.location &&
+    window.location.protocol === 'file:';
 
   const renderItems = (items) => {
     clearList(listEl);


### PR DESCRIPTION
## Summary
- replace optional chaining when detecting the file protocol so the index script runs on older browsers

## Testing
- no automated tests provided

------
https://chatgpt.com/codex/tasks/task_e_68d5649986c88323918d92c5f3a43e07