### PR TITLE
Restore preloaded homepage poem list

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -288,8 +288,34 @@
 
         <section class="poem-index" aria-labelledby="poem-index-heading">
           <h2 id="poem-index-heading">Poemas publicados</h2>
-          <p id="status-root" role="status">Cargando poemas…</p>
-          <ul id="poem-list-root"></ul>
+          <p id="status-root" role="status">Lista precargada desde index.md.</p>
+          <ul id="poem-list-root">
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=I%20want%20it%20to%20hurt.md">I want it to hurt</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Me%20pica.md">Me pica</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Amigos.md">Amigos</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=A%20nadie%2C%20nunca.md">A nadie, nunca</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Miradas.md">Miradas</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Listas.md">Listas</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Siempre.md">Siempre</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Notificaciones.md">Notificaciones</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Inconsciente.md">Inconsciente</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Escribo.md">Escribo</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Falta.md">Falta</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Hospital.md">Hospital</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Why%20is%20it%20like%20this.md">Why is it like this</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Creencias.md">Creencias</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Sound.md">Sound</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Kintsugi.md">Kintsugi</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Ganas.md">Ganas</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Este%20chico.md">Este chico</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Magnifico.md">Magnifico</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=No%20estoy%20a%20la%20altura.md">No estoy a la altura</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Scars.md">Scars</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Body.md">Body</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=My%20big%20dream.md">My big dream</a></li>
+            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Delirios%20en%20la%20ducha.md">Delirios en la ducha</a></li>
+            <li class="more-items muted">… y 55 poemas más en el índice completo.</li>
+          </ul>
           <p class="muted" id="hint-root" hidden>
             Algunos enlaces aparecen sin archivo porque falta el <code>.md</code> correspondiente.
             Guárdalo dentro de <code>notes/Escritos/Canciones-poemas-escritos/</code> y vuelve a publicar.


### PR DESCRIPTION
## Summary
- merge the conflicting homepage variants by keeping the new layout with navigation
- restore the preloaded poem index markup and status text so visitors see links before JavaScript runs

## Testing
- Manual verification of the homepage in a local browser

------
https://chatgpt.com/codex/tasks/task_e_68d69c72b9e08323a02b5f4ab0a4e467