### PR TITLE
Remove homepage poem list limit

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,4 +1,240 @@
-             Carga los poemas en pantalla completa con tipografía cuidada y controles para navegar el cuaderno como si
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Takumi’s Garden</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg-color: #05010a;
+        --panel-color: #12061d;
+        --panel-border: rgba(255, 95, 162, 0.3);
+        --text-color: #fce6f6;
+        --muted-color: #d6a9c5;
+        --accent-color: #ff5fa2;
+        --accent-strong: #ff82c0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), var(--bg-color);
+        color: var(--text-color);
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      a {
+        color: var(--accent-strong);
+      }
+
+      .container {
+        width: min(68rem, 100%);
+        margin-inline: auto;
+        padding: 0 1.5rem;
+      }
+
+      header.hero {
+        padding: 4.5rem 0 3rem;
+        text-align: center;
+      }
+
+      header.hero p.tagline {
+        margin: 0;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        color: var(--muted-color);
+      }
+
+      header.hero h1 {
+        margin: 0.6rem 0 1rem;
+        font-size: clamp(2.5rem, 5vw, 3.4rem);
+        letter-spacing: 0.05em;
+        color: var(--accent-color);
+      }
+
+      header.hero p.lead {
+        margin: 0 auto 2rem;
+        max-width: 40rem;
+        color: var(--muted-color);
+        font-size: 1.05rem;
+        line-height: 1.7;
+      }
+
+      .cta {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.75rem;
+      }
+
+      .cta a {
+        border-radius: 999px;
+        border: 1px solid var(--accent-color);
+        padding: 0.75rem 1.65rem;
+        font-weight: 600;
+        text-decoration: none;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        background: rgba(255, 95, 162, 0.12);
+        box-shadow: 0 18px 35px rgba(10, 2, 20, 0.45);
+      }
+
+      .cta a.secondary {
+        background: transparent;
+        border-color: rgba(255, 95, 162, 0.45);
+        box-shadow: none;
+      }
+
+      .cta a:hover,
+      .cta a:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 20px 40px rgba(10, 2, 20, 0.6);
+      }
+
+      main {
+        padding-bottom: 4rem;
+      }
+
+      section.features {
+        display: grid;
+        gap: 1.5rem;
+        margin-bottom: 3.5rem;
+      }
+
+      section.features article {
+        background: var(--panel-color);
+        border-radius: 1.5rem;
+        border: 1px solid var(--panel-border);
+        padding: 1.75rem;
+        box-shadow: 0 25px 50px rgba(10, 2, 20, 0.55);
+      }
+
+      section.features h3 {
+        margin-top: 0;
+        color: var(--accent-color);
+      }
+
+      section.features p {
+        color: var(--muted-color);
+        margin-bottom: 1.1rem;
+      }
+
+      section.features a.more {
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      @media (min-width: 54rem) {
+        section.features {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+      }
+
+      section.poem-index h2 {
+        margin-bottom: 0.25rem;
+        color: var(--accent-color);
+      }
+
+      section.poem-index p[role='status'] {
+        color: var(--muted-color);
+      }
+
+      ul#poem-list-root {
+        list-style: none;
+        padding: 1.75rem;
+        margin: 1.75rem 0 1.25rem;
+        columns: 1;
+        column-gap: 2.5rem;
+        background: var(--panel-color);
+        border-radius: 1.5rem;
+        border: 1px solid var(--panel-border);
+        box-shadow: 0 25px 50px rgba(10, 2, 20, 0.55);
+      }
+
+      @media (min-width: 56rem) {
+        ul#poem-list-root {
+          columns: 2;
+        }
+      }
+
+      ul#poem-list-root li {
+        break-inside: avoid;
+        margin-bottom: 0.45rem;
+      }
+
+      ul#poem-list-root li a {
+        text-decoration: none;
+        color: var(--text-color);
+        position: relative;
+      }
+
+      ul#poem-list-root li a::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        bottom: -0.1rem;
+        width: 100%;
+        height: 0.1rem;
+        background: linear-gradient(90deg, transparent, var(--accent-strong), transparent);
+        transform: scaleX(0);
+        transform-origin: center;
+        transition: transform 0.2s ease;
+      }
+
+      ul#poem-list-root li a:hover::after,
+      ul#poem-list-root li a:focus-visible::after {
+        transform: scaleX(1);
+      }
+
+      ul#poem-list-root li.missing {
+        color: rgba(255, 152, 188, 0.8);
+      }
+
+      ul#poem-list-root li.missing span {
+        font-size: 0.9em;
+        margin-left: 0.35rem;
+        color: inherit;
+      }
+
+      .muted {
+        color: var(--muted-color);
+      }
+
+      footer {
+        padding: 2.5rem 0 3rem;
+        text-align: center;
+        color: var(--muted-color);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="hero">
+      <div class="container">
+        <p class="tagline">Poemas, canciones y escritos desde el jardín de Takumi.</p>
+        <h1>Takumi’s Garden</h1>
+        <p class="lead">
+          Un cuaderno digital que recopila versos íntimos, borradores y notas sueltas. Explora el índice navegable
+          o abre el visor para leer cada poema con el ambiente rosa &amp; negro.
+        </p>
+        <div class="cta">
+          <a href="notes/Escritos/Canciones-poemas-escritos/viewer.html">Abrir visor</a>
+          <a class="secondary" href="notes/Escritos/Canciones-poemas-escritos/">Ir al índice completo</a>
+        </div>
+      </div>
+    </header>
+    <main>
+      <div class="container">
+        <section class="features" aria-label="Accesos directos">
+          <article>
+            <h3>Visor inmersivo</h3>
+            <p>
+              Carga los poemas en pantalla completa con tipografía cuidada y controles para navegar el cuaderno como si
               fuera una publicación impresa.
             </p>
             <a class="more" href="notes/Escritos/Canciones-poemas-escritos/viewer.html">Abrir visor</a>
@@ -25,34 +261,6 @@
           <h2 id="poem-index-heading">Poemas publicados</h2>
           <p id="status-root" role="status">Cargando poemas…</p>
           <ul id="poem-list-root"></ul>
-          <p id="status-root" role="status">Lista precargada desde index.md.</p>
-          <ul id="poem-list-root">
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=I%20want%20it%20to%20hurt.md">I want it to hurt</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Me%20pica.md">Me pica</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Amigos.md">Amigos</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=A%20nadie%2C%20nunca.md">A nadie, nunca</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Miradas.md">Miradas</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Listas.md">Listas</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Siempre.md">Siempre</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Notificaciones.md">Notificaciones</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Inconsciente.md">Inconsciente</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Escribo.md">Escribo</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Falta.md">Falta</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Hospital.md">Hospital</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Why%20is%20it%20like%20this.md">Why is it like this</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Creencias.md">Creencias</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Sound.md">Sound</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Kintsugi.md">Kintsugi</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Ganas.md">Ganas</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Este%20chico.md">Este chico</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Magnifico.md">Magnifico</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=No%20estoy%20a%20la%20altura.md">No estoy a la altura</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Scars.md">Scars</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Body.md">Body</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=My%20big%20dream.md">My big dream</a></li>
-            <li><a href="notes/Escritos/Canciones-poemas-escritos/viewer.html?file=Delirios%20en%20la%20ducha.md">Delirios en la ducha</a></li>
-            <li class="more-items muted">… y 55 poemas más en el índice completo.</li>
-          </ul>
           <p class="muted" id="hint-root" hidden>
             Algunos enlaces aparecen sin archivo porque falta el <code>.md</code> correspondiente.
             Guárdalo dentro de <code>notes/Escritos/Canciones-poemas-escritos/</code> y vuelve a publicar.
@@ -77,4 +285,107 @@ dg-permalink: /Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/
 ---
 [[I want it to hurt|I want it to hurt]]
 [[Me pica|Me pica]]
-[[Amigos|Amigos]]
+[[Amigos|Amigos]]  
+[[A nadie, nunca|A nadie, nunca]]  
+[[Miradas|Miradas]]  
+[[Listas|Listas]]  
+[[Siempre|Siempre]]  
+[[Notificaciones|Notificaciones]]  
+[[Inconsciente|Inconsciente]]  
+[[Escribo|Escribo]]  
+[[Falta|Falta]]  
+[[Hospital|Hospital]]  
+[[Why is it like this|Why is it like this]]  
+[[Creencias|Creencias]]  
+[[Sound|Sound]]  
+[[Kintsugi|Kintsugi]]  
+[[Ganas|Ganas]]  
+[[Este chico|Este chico]]  
+[[Magnifico|Magnifico]]  
+[[No estoy a la altura|No estoy a la altura]]  
+[[Scars|Scars]]  
+[[Body|Body]]  
+[[My big dream|My big dream]]  
+[[Delirios en la ducha|Delirios en la ducha]]  
+[[Pastis|Pastis]]  
+[[Basura|Basura]]  
+[[Escenarios|Escenarios]]  
+[[Eli x2|Eli x2]]  
+[[Delgado|Delgado]]  
+[[Porro|Porro]]  
+[[Me ha dado miedo|Me ha dado miedo]]  
+[[Repito|Repito]]  
+[[No es justo|No es justo]]  
+[[In the neck|In the neck]]  
+[[Indicaciones|Indicaciones]]  
+[[Alcohol|Alcohol]]  
+[[Sombras|Sombras]]  
+[[Aphantasia|Aphantasia]]  
+[[¿Para que|¿Para que]]  
+[[Duele|Duele]]  
+[[Envejecer|Envejecer]]  
+[[Same thing|Same thing]]  
+[[Abuelo|Abuelo]]  
+[[No entiendo|No entiendo]]  
+[[Terapeuta virtual|Terapeuta virtual]]  
+[[Perdido|Perdido]]  
+[[Alone|Alone]]  
+[[El lastimado|El lastimado]]  
+[[Mi cerebro|Mi cerebro]]  
+[[Afilado|Afilado]]  
+[[Me volvieron a dejar|Me volvieron a dejar]]  
+[[Random vent|Random vent]]  
+[[Llanto|Llanto]]  
+[[Vacio|Vacio]]  
+[[SHP.com|SHP.com]]  
+[[Casi lo hago|Casi lo hago]]  
+[[Cronico|Cronico]]  
+[[En que piensas|En que piensas]]  
+[[Todo|Todo]]  
+[[Disposable|Disposable]]  
+[[Calladito|Calladito]]  
+[[Todo mal|Todo mal]]  
+[[Borroso|Borroso]]  
+[[Waking up or falling down|Waking up or falling down]]  
+[[Escapulas|Escapulas]]  
+[[En la sien|En la sien]]  
+[[3 en ralla|3 en ralla]]  
+[[Tik tok curse|Tik tok curse]]  
+[[Creo que tengo tlp|Creo que tengo tlp]]  
+[[Mala hija|Mala hija]]  
+[[Padres|Padres]]  
+[[Las veces que he despertado|Las veces que he despertado]]  
+[[Slit|Slit]]  
+[[Irrealidad|Irrealidad]]  
+[[Redentor en ruinas|Redentor en ruinas]]  
+[[Mi deseo|Mi deseo]]  
+[[TEA|TEA]]  
+[[Seen|Seen]]  
+[[Sex|Sex]]
+    </script>
+    <script src="assets/poem-index.js"></script>
+    <script>
+      (function () {
+        if (typeof initPoemIndex !== 'function') {
+          return;
+        }
+
+        var fallbackSource = document.getElementById('poem-index-markdown');
+        var fallbackMarkdown = null;
+        if (fallbackSource && typeof fallbackSource.textContent === 'string') {
+          fallbackMarkdown = fallbackSource.textContent.trim();
+        }
+
+        initPoemIndex({
+          listSelector: '#poem-list-root',
+          statusSelector: '#status-root',
+          hintSelector: '#hint-root',
+          indexPath: 'notes/Escritos/Canciones-poemas-escritos/index.md',
+          viewerBase: 'notes/Escritos/Canciones-poemas-escritos/viewer.html',
+          fileBase: 'notes/Escritos/Canciones-poemas-escritos/',
+          fallbackMarkdown: fallbackMarkdown,
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- show the full set of poems on the Takumi’s Garden landing page by removing the artificial 24-item limit

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d69f3a6e5483239643311856af1f70