### PR TITLE
Add stubs for latest poems and refresh listings

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -283,7 +283,10 @@ title: Canciones, poemas y escritos
 dg-publish: true
 dg-permalink: /Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/
 ---
+[[Recuerdos|Recuerdos]]
+[[Brazos|Brazos]]
 [[I want it to hurt|I want it to hurt]]
+[[Amantes|Amantes]]
 [[Me pica|Me pica]]
 [[Amigos|Amigos]]  
 [[A nadie, nunca|A nadie, nunca]]  

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/Amantes.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/Amantes.md
@@ -1,0 +1,8 @@
+---
+Fecha de creación: 2025-09-30T00:00:00
+Idioma: Spanish
+Número: null
+dg-publish: true
+---
+
+<!-- Contenido pendiente de transcribir para "Amantes". -->

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/Brazos.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/Brazos.md
@@ -1,0 +1,8 @@
+---
+Fecha de creación: 2025-09-30T00:00:00
+Idioma: Spanish
+Número: null
+dg-publish: true
+---
+
+<!-- Contenido pendiente de transcribir para "Brazos". -->

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/I want it to hurt.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/I want it to hurt.md
@@ -1,0 +1,8 @@
+---
+Fecha de creación: 2025-09-30T00:00:00
+Idioma: English
+Número: null
+dg-publish: true
+---
+
+<!-- Content pending transcription for "I want it to hurt". -->

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/Me pica.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/Me pica.md
@@ -1,3 +1,10 @@
+---
+Fecha de creación: 2025-09-23T22:35:16
+Idioma: Spanish
+Número: null
+dg-publish: true
+---
+
 Me pica, me pica tanto que casi escuece.
 Escuece, y empieza a doler.
 

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/Quiero que duela.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/Quiero que duela.md
@@ -1,1 +1,0 @@
-Quiero que duela como 

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/Recuerdos.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/Recuerdos.md
@@ -1,0 +1,8 @@
+---
+Fecha de creación: 2025-09-30T00:00:00
+Idioma: Spanish
+Número: null
+dg-publish: true
+---
+
+<!-- Contenido pendiente de transcribir para "Recuerdos". -->

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/index.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/index.md
@@ -2,8 +2,10 @@
 title: Canciones, poemas y escritos
 dg-publish: true
 dg-permalink: /Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/
----
+[[Recuerdos|Recuerdos]]
+[[Brazos|Brazos]]
 [[I want it to hurt|I want it to hurt]]
+[[Amantes|Amantes]]
 [[Me pica|Me pica]]
 [[Amigos|Amigos]]  
 [[A nadie, nunca|A nadie, nunca]]  


### PR DESCRIPTION
## Summary
- replace the removed poem “Quiero que duela” with publish-ready stubs for “Recuerdos”, “Brazos”, “I want it to hurt” and “Amantes”
- refresh the poem index and homepage fallback to surface the new titles

## Testing
- python fix_index_links.py --index src/site/notes/Escritos/Canciones-poemas-escritos/index.md

------
https://chatgpt.com/codex/tasks/task_e_68db9b1b23ac8323947f8c9cbc27552f