### PR TITLE
Replace Notas del jardín section with Días de colores

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -248,12 +248,12 @@
             <a class="more" href="notes/Escritos/Canciones-poemas-escritos/">Ir al índice</a>
           </article>
           <article>
-            <h3>Notas del jardín</h3>
+            <h3>Días de colores</h3>
             <p>
-              Además de los poemas, encontrarás textos sueltos y material de referencia en la carpeta general de notas.
-              Es la mejor forma de seguir el proceso creativo.
+              Una nueva colección de semillas cromáticas. Cada entrada captura un tono, una sensación y una frase breve
+              para inspirar futuros escritos.
             </p>
-            <a class="more" href="notes/">Explorar notas</a>
+            <a class="more" href="notes/escritos/dias-de-colores/">Ver la paleta</a>
           </article>
         </section>
 

--- a/src/site/notes/Escritos/Dias de colores/index.md
+++ b/src/site/notes/Escritos/Dias de colores/index.md
@@ -1,0 +1,8 @@
+---
+{"dg-publish":true,"dg-permalink":"/escritos/dias-de-colores/","title":"Días de colores"}
+---
+
+> [!summary] Paleta sentimental
+> Miniaturas con colores que guardan recuerdos. Cada nota es una semilla cromática lista para crecer en futuras historias.
+
+- [[Escritos/Dias de colores/Verde melancólico 🌱|Verde melancólico 🌱]]


### PR DESCRIPTION
## Summary
- update the landing page feature tile to present the new **Días de colores** section and link straight to its palette
- add a published index page for the Días de colores collection with a short description and the current entry

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbcc84c9a08323880882208c0171de