### PR TITLE
Fix Días de colores navigation links

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -248,12 +248,12 @@
             <a class="more" href="notes/Escritos/Canciones-poemas-escritos/">Ir al índice</a>
           </article>
           <article>
-            <h3>Notas del jardín</h3>
+            <h3>Días de colores</h3>
             <p>
-              Además de los poemas, encontrarás textos sueltos y material de referencia en la carpeta general de notas.
-              Es la mejor forma de seguir el proceso creativo.
+              Una nueva colección de semillas cromáticas. Cada entrada captura un tono, una sensación y una frase breve
+              para inspirar futuros escritos.
             </p>
-            <a class="more" href="notes/">Explorar notas</a>
+            <a class="more" href="notes/Escritos/Dias%20de%20colores/">Ver la paleta</a>
           </article>
         </section>
 

--- a/src/site/notes/Escritos/Dias de colores/Verde melancólico 🌱.md
+++ b/src/site/notes/Escritos/Dias de colores/Verde melancólico 🌱.md
@@ -1,5 +1,5 @@
 ---
-{"dg-publish":true,"permalink":"/escritos/dias-de-colores/verde-melancolico/","tags":["semillas","color"]}
+{"dg-publish":true,"permalink":"/escritos/dias-de-colores/verde-melancolico/","title":"Verde melancólico 🌱","tags":["semillas","color"]}
 ---
 
 
@@ -9,5 +9,9 @@
 
 - 🎨 **Código HEX:** `#93997B`
 - 📷 **Imagen:** ![20250930_123341.jpg](/img/user/20250930_123341.jpg)
-- ✍️ **Frase:** "Verde que trae recuerdos y no de los buenos, verde del que dan ganas  de lanzarse..." 
+- ✍️ **Frase:** "Verde que trae recuerdos y no de los buenos, verde del que dan ganas  de lanzarse..."
+
+---
+
+[⬅️ Volver al índice de Días de colores](../)
 

--- a/src/site/notes/Escritos/Dias de colores/index.md
+++ b/src/site/notes/Escritos/Dias de colores/index.md
@@ -1,0 +1,72 @@
+---
+{"dg-publish":true,"dg-permalink":"/escritos/dias-de-colores/","permalink":"/escritos/dias-de-colores/","title":"Días de colores"}
+---
+
+> [!summary] Paleta sentimental
+> Miniaturas con colores que guardan recuerdos. Cada nota es una semilla cromática lista para crecer en futuras historias.
+
+<style>
+.palette-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.palette-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.35rem;
+  border-radius: 1.15rem;
+  text-decoration: none;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 35px rgba(5, 1, 10, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.palette-card:hover,
+.palette-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 28px 48px rgba(5, 1, 10, 0.45);
+}
+
+.palette-card .swatch {
+  width: 100%;
+  aspect-ratio: 5 / 2;
+  border-radius: 0.9rem;
+  background: var(--tone);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.palette-card .tone-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.palette-card .tone-meta {
+  font-family: "Fira Code", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  letter-spacing: 0.06em;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.palette-card .tone-quote {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+</style>
+
+<div class="palette-grid">
+  <a class="palette-card" href="verde-melancolico/">
+    <span class="swatch" style="--tone:#93997B;"></span>
+    <span class="tone-name">Verde melancólico 🌱</span>
+    <span class="tone-meta">#93997B</span>
+    <span class="tone-quote">
+      &ldquo;Verde que trae recuerdos y no de los buenos, verde del que dan ganas de lanzarse...&rdquo;
+    </span>
+  </a>
+</div>


### PR DESCRIPTION
## Summary
- point the home page shortcut for Días de colores to the published folder in the repository
- update the palette index metadata and card link to use relative paths so the entries resolve under the site base path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcc84c9a08323880882208c0171de