### PR TITLE
Publish Naranja en espera tone for Días de colores

### DIFF
--- a/src/site/notes/Escritos/Dias de colores/index.html
+++ b/src/site/notes/Escritos/Dias de colores/index.html
@@ -142,6 +142,12 @@
 
       <main>
         <div class="palette-grid" role="list">
+          <a class="palette-card" href="naranja-en-espera/" role="listitem">
+            <span class="swatch" style="--tone: #DC7630"></span>
+            <span class="tone-name">Naranja en espera 🟧</span>
+            <span class="tone-meta">#DC7630</span>
+            <span class="tone-quote">“Estoy en la sala de espera, he visto a Paula, con Lorena ha ido bien.”</span>
+          </a>
           <a class="palette-card" href="verde-melancolico/" role="listitem">
             <span class="swatch" style="--tone: #93997B"></span>
             <span class="tone-name">Verde melancólico 🌱</span>
@@ -152,7 +158,7 @@
       </main>
 
       <footer>
-        Última actualización: 1 tono publicado.
+        Última actualización: 2 tonos publicados.
       </footer>
     </div>
   </body>

--- a/src/site/notes/Escritos/Dias de colores/index.md
+++ b/src/site/notes/Escritos/Dias de colores/index.md
@@ -62,6 +62,15 @@
 </style>
 
 <div class="palette-grid">
+  <a class="palette-card" href="/escritos/dias-de-colores/naranja-en-espera/">
+
+    <span class="swatch" style="--tone:#DC7630;"></span>
+    <span class="tone-name">Naranja en espera 🟧</span>
+    <span class="tone-meta">#DC7630</span>
+    <span class="tone-quote">
+      &ldquo;Estoy en la sala de espera, he visto a Paula, con Lorena ha ido bien.&rdquo;
+    </span>
+  </a>
   <a class="palette-card" href="/escritos/dias-de-colores/verde-melancolico/">
 
     <span class="swatch" style="--tone:#93997B;"></span>

--- a/src/site/notes/Escritos/Dias de colores/naranja-en-espera/index.html
+++ b/src/site/notes/Escritos/Dias de colores/naranja-en-espera/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Naranja en espera 🟧 · Días de colores · Takumi’s Garden</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #05010a;
+        --panel: rgba(255, 255, 255, 0.05);
+        --border: rgba(255, 255, 255, 0.12);
+        --accent: #ffb347;
+        --muted: rgba(255, 255, 255, 0.72);
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at top, rgba(255, 179, 71, 0.18), transparent 55%), var(--bg);
+        color: #ffeadd;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .page {
+        width: min(42rem, 100%);
+        margin-inline: auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+
+      nav.breadcrumbs {
+        margin-bottom: 2rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 0.75rem;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      nav.breadcrumbs a {
+        color: var(--muted);
+        text-decoration: none;
+      }
+
+      nav.breadcrumbs a:hover,
+      nav.breadcrumbs a:focus-visible {
+        color: #ffeadd;
+        text-decoration: underline;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 5vw, 2.8rem);
+        color: var(--accent);
+      }
+
+      .tone-meta {
+        margin: 1rem 0 0;
+        padding: 1.5rem;
+        border-radius: 1.25rem;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .swatch {
+        width: 100%;
+        height: 90px;
+        border-radius: 1rem;
+        background: #DC7630;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+      }
+
+      .details {
+        display: grid;
+        gap: 0.65rem;
+        font-size: 0.95rem;
+      }
+
+      .details strong {
+        font-weight: 600;
+      }
+
+      .tone-quote {
+        margin-top: 2rem;
+        font-size: 1.05rem;
+        font-style: italic;
+        line-height: 1.7;
+        color: var(--muted);
+      }
+
+      .tone-quote em {
+        color: #ffeadd;
+        font-style: normal;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../../../../index.html">← Volver al jardín</a>
+        <span aria-hidden="true">/</span>
+        <a href="../index.html">Días de colores</a>
+        <span aria-hidden="true">/</span>
+        <span>Naranja en espera 🟧</span>
+      </nav>
+
+      <header>
+        <h1>Naranja en espera 🟧</h1>
+      </header>
+
+      <section class="tone-meta">
+        <div class="swatch" role="img" aria-label="Muestra de color naranja en espera"></div>
+        <div class="details">
+          <div><strong>🎨 Código HEX:</strong> <code>#DC7630</code></div>
+          <div><strong>📷 Imagen:</strong> <a href="../../../../img/user/20251001_091658.jpg">20251001_091658.jpg</a></div>
+        </div>
+      </section>
+
+      <p class="tone-quote">“Estoy en la sala de espera, he visto a Paula, con Lorena ha ido bien.”</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- publish the “Naranja en espera” tone page with dedicated styling and metadata
- expose the new tone from the Días de colores index with its swatch and quote
- update the palette overview footer to reflect the additional published tone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dceca37e6883239087dce0fd3c8dbb