### PR TITLE
Fix poem preview missing file warnings

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -264,7 +264,8 @@
           <ul id="poem-list-root"></ul>
           <p class="muted" id="hint-root" hidden>
             Algunos enlaces aparecen sin archivo porque falta el <code>.md</code> correspondiente.
-            Guárdalo dentro de <code>notes/Escritos/Canciones-poemas-escritos/</code> y vuelve a publicar.
+            Guárdalo dentro de <code>notes/Escritos/Canciones-poemas-escritos/Canciones poemas escritos/</code> y vuelve a
+            publicar.
           </p>
           <p class="muted">¿Buscas un título en particular? Abre el índice completo para verlo todo.</p>
         </section>
@@ -280,92 +281,92 @@
     </noscript>
     <script id="poem-index-markdown" type="application/json">
 ---
-title: Canciones, poemas y escritos
-dg-publish: true
-dg-permalink: /Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/
+{"dg-publish":true,"dg-permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","title":"Canciones, poemas y escritos"}
 ---
-[[Amantes|Amantes]]
-[[Brazos|Brazos]]
-[[Recuerdos|Recuerdos]]
-[[Me pica|Me pica]]
-[[I want it to hurt|I want it to hurt]]
-[[Amigos|Amigos]]  
-[[A nadie, nunca|A nadie, nunca]]  
-[[Miradas|Miradas]]  
-[[Listas|Listas]]  
-[[Siempre|Siempre]]  
-[[Notificaciones|Notificaciones]]  
-[[Inconsciente|Inconsciente]]  
-[[Escribo|Escribo]]  
-[[Falta|Falta]]  
-[[Hospital|Hospital]]  
-[[Why is it like this|Why is it like this]]  
-[[Creencias|Creencias]]  
-[[Sound|Sound]]  
-[[Kintsugi|Kintsugi]]  
-[[Ganas|Ganas]]  
-[[Este chico|Este chico]]  
-[[Magnifico|Magnifico]]  
-[[No estoy a la altura|No estoy a la altura]]  
-[[Scars|Scars]]  
-[[Body|Body]]  
-[[My big dream|My big dream]]  
-[[Delirios en la ducha|Delirios en la ducha]]  
-[[Pastis|Pastis]]  
-[[Basura|Basura]]  
-[[Escenarios|Escenarios]]  
-[[Eli x2|Eli x2]]  
-[[Delgado|Delgado]]  
-[[Porro|Porro]]  
-[[Me ha dado miedo|Me ha dado miedo]]  
-[[Repito|Repito]]  
-[[No es justo|No es justo]]  
-[[In the neck|In the neck]]  
-[[Indicaciones|Indicaciones]]  
-[[Alcohol|Alcohol]]  
-[[Sombras|Sombras]]  
-[[Aphantasia|Aphantasia]]  
-[[¿Para que|¿Para que]]  
-[[Duele|Duele]]  
-[[Envejecer|Envejecer]]  
-[[Same thing|Same thing]]  
-[[Abuelo|Abuelo]]  
-[[No entiendo|No entiendo]]  
-[[Terapeuta virtual|Terapeuta virtual]]  
-[[Perdido|Perdido]]  
-[[Alone|Alone]]  
-[[El lastimado|El lastimado]]  
-[[Mi cerebro|Mi cerebro]]  
-[[Afilado|Afilado]]  
-[[Me volvieron a dejar|Me volvieron a dejar]]  
-[[Random vent|Random vent]]  
-[[Llanto|Llanto]]  
-[[Vacio|Vacio]]  
-[[SHP.com|SHP.com]]  
-[[Casi lo hago|Casi lo hago]]  
-[[Cronico|Cronico]]  
-[[En que piensas|En que piensas]]  
-[[Todo|Todo]]  
-[[Disposable|Disposable]]  
-[[Calladito|Calladito]]  
-[[Todo mal|Todo mal]]  
-[[Borroso|Borroso]]  
-[[Waking up or falling down|Waking up or falling down]]  
-[[Escapulas|Escapulas]]  
-[[En la sien|En la sien]]  
-[[3 en ralla|3 en ralla]]  
-[[Tik tok curse|Tik tok curse]]  
-[[Creo que tengo tlp|Creo que tengo tlp]]  
-[[Mala hija|Mala hija]]  
-[[Padres|Padres]]  
-[[Las veces que he despertado|Las veces que he despertado]]  
-[[Slit|Slit]]  
-[[Irrealidad|Irrealidad]]  
-[[Redentor en ruinas|Redentor en ruinas]]  
-[[Mi deseo|Mi deseo]]  
-[[TEA|TEA]]  
-[[Seen|Seen]]  
-[[Sex|Sex]]
+
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Pereza\|Pereza]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Amantes\|Amantes]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Brazos\|Brazos]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Recuerdos\|Recuerdos]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Me pica\|Me pica]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/I want it to hurt\|I want it to hurt]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Amigos\|Amigos]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/A nadie, nunca\|A nadie, nunca]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Miradas\|Miradas]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Listas\|Listas]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Siempre\|Siempre]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Notificaciones\|Notificaciones]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Inconsciente\|Inconsciente]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Escribo\|Escribo]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Falta\|Falta]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Hospital\|Hospital]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Why is it like this\|Why is it like this]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Creencias\|Creencias]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Sound\|Sound]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Kintsugi\|Kintsugi]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Ganas\|Ganas]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Este chico\|Este chico]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Magnifico\|Magnifico]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/No estoy a la altura\|No estoy a la altura]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Scars\|Scars]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Body\|Body]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/My big dream\|My big dream]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Delirios en la ducha\|Delirios en la ducha]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Pastis\|Pastis]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Basura\|Basura]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Escenarios\|Escenarios]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Eli x2\|Eli x2]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Delgado\|Delgado]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Porro\|Porro]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Me ha dado miedo\|Me ha dado miedo]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Repito\|Repito]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/No es justo\|No es justo]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/In the neck\|In the neck]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Indicaciones\|Indicaciones]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Alcohol\|Alcohol]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Sombras\|Sombras]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Aphantasia\|Aphantasia]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/¿Para que\|¿Para que]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Duele\|Duele]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Envejecer\|Envejecer]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Same thing\|Same thing]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Abuelo\|Abuelo]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/No entiendo\|No entiendo]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Terapeuta virtual\|Terapeuta virtual]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Perdido\|Perdido]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Alone\|Alone]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/El lastimado\|El lastimado]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Mi cerebro\|Mi cerebro]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Afilado\|Afilado]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Me volvieron a dejar\|Me volvieron a dejar]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Random vent\|Random vent]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Llanto\|Llanto]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Vacio\|Vacio]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/SHP.com\|SHP.com]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Casi lo hago\|Casi lo hago]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Cronico\|Cronico]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/En que piensas\|En que piensas]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Todo\|Todo]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Disposable\|Disposable]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Calladito\|Calladito]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Todo mal\|Todo mal]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Borroso\|Borroso]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Waking up or falling down\|Waking up or falling down]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Escapulas\|Escapulas]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/En la sien\|En la sien]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/3 en ralla\|3 en ralla]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Tik tok curse\|Tik tok curse]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Creo que tengo tlp\|Creo que tengo tlp]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Mala hija\|Mala hija]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Padres\|Padres]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Las veces que he despertado\|Las veces que he despertado]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Slit\|Slit]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Irrealidad\|Irrealidad]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Redentor en ruinas\|Redentor en ruinas]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Mi deseo\|Mi deseo]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/TEA\|TEA]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Seen\|Seen]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Sex\|Sex]]
     </script>
     <script src="assets/poem-index.js"></script>
     <script>
@@ -384,12 +385,12 @@ dg-permalink: /Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/
           listSelector: '#poem-list-root',
           statusSelector: '#status-root',
           hintSelector: '#hint-root',
-          indexPath: 'notes/Escritos/Canciones-poemas-escritos/index.md',
+          indexPath:
+            'notes/Escritos/Canciones-poemas-escritos/Canciones%20poemas%20escritos/index.md',
           viewerBase: 'notes/Escritos/Canciones-poemas-escritos/viewer.html',
-fileBase: 'notes/Escritos/Canciones-poemas-escritos/',
-limit: 24,
-fallbackMarkdown: fallbackMarkdown,
-
+          fileBase: 'notes/',
+          limit: 24,
+          fallbackMarkdown: fallbackMarkdown,
         });
       })();
     </script>

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/Canciones poemas escritos/index.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/Canciones poemas escritos/index.md
@@ -2,6 +2,7 @@
 {"dg-publish":true,"dg-permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","title":"Canciones, poemas y escritos"}
 ---
 
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Pereza\|Pereza]]
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Amantes\|Amantes]]
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Brazos\|Brazos]]
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Recuerdos\|Recuerdos]]
@@ -33,9 +34,9 @@
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Basura\|Basura]]  
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Escenarios\|Escenarios]]  
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Eli x2\|Eli x2]]  
-[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Delgado\|Delgado]]  
-[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Porro\|Porro]]  
-[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Me ha dado miedo\|Me ha dado miedo]]  
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Delgado\|Delgado]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Porro\|Porro]]
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Me ha dado miedo\|Me ha dado miedo]]
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Repito\|Repito]]  
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/No es justo\|No es justo]]  
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/In the neck\|In the neck]]  


### PR DESCRIPTION
## Summary
- update the preloaded poem index markup to use the full Obsidian link targets so viewer URLs stay valid
- adjust the homepage loader to fetch the canonical index file and check poem files via encoded path segments under the notes directory
- refresh the missing-file hint to point to the correct folder that holds the poem Markdown files

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dd8653159483239c6c2bcce6afe769