### PR TITLE
Add redirects for Días de colores routes

### DIFF
--- a/src/site/escritos/dias-de-colores/blanco-de-nuevos-comienzos/index.html
+++ b/src/site/escritos/dias-de-colores/blanco-de-nuevos-comienzos/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Blanco de nuevos comienzos · Redirección</title>
+    <meta http-equiv="refresh" content="0; url=/notes/Escritos/Dias%20de%20colores/blanco-de-nuevos-comienzos/index.html" />
+    <link rel="canonical" href="/notes/Escritos/Dias%20de%20colores/blanco-de-nuevos-comienzos/index.html" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #05010a;
+        color: #fce6f6;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 3rem 1.5rem;
+        text-align: center;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), #05010a;
+      }
+      a {
+        color: #ff82c0;
+      }
+      p {
+        max-width: 32rem;
+        line-height: 1.6;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirigiendo a Blanco de nuevos comienzos…</h1>
+      <p>
+        Si no eres redirigido automáticamente, visita
+        <a href="/notes/Escritos/Dias%20de%20colores/blanco-de-nuevos-comienzos/index.html">la versión actualizada del poema</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/src/site/escritos/dias-de-colores/index.html
+++ b/src/site/escritos/dias-de-colores/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Días de colores · Redirección</title>
+    <meta http-equiv="refresh" content="0; url=/notes/Escritos/Dias%20de%20colores/index.html" />
+    <link rel="canonical" href="/notes/Escritos/Dias%20de%20colores/index.html" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #05010a;
+        color: #fce6f6;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 3rem 1.5rem;
+        text-align: center;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), #05010a;
+      }
+      a {
+        color: #ff82c0;
+      }
+      p {
+        max-width: 32rem;
+        line-height: 1.6;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirigiendo a Días de colores…</h1>
+      <p>
+        Si no eres redirigido automáticamente, visita
+        <a href="/notes/Escritos/Dias%20de%20colores/index.html">la nueva página de Días de colores</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/src/site/escritos/dias-de-colores/naranja-en-espera/index.html
+++ b/src/site/escritos/dias-de-colores/naranja-en-espera/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Naranja en espera · Redirección</title>
+    <meta http-equiv="refresh" content="0; url=/notes/Escritos/Dias%20de%20colores/naranja-en-espera/index.html" />
+    <link rel="canonical" href="/notes/Escritos/Dias%20de%20colores/naranja-en-espera/index.html" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #05010a;
+        color: #fce6f6;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 3rem 1.5rem;
+        text-align: center;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), #05010a;
+      }
+      a {
+        color: #ff82c0;
+      }
+      p {
+        max-width: 32rem;
+        line-height: 1.6;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirigiendo a Naranja en espera…</h1>
+      <p>
+        Si no eres redirigido automáticamente, visita
+        <a href="/notes/Escritos/Dias%20de%20colores/naranja-en-espera/index.html">la versión actualizada del poema</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/src/site/escritos/dias-de-colores/verde-melancolico/index.html
+++ b/src/site/escritos/dias-de-colores/verde-melancolico/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Verde melancólico · Redirección</title>
+    <meta http-equiv="refresh" content="0; url=/notes/Escritos/Dias%20de%20colores/verde-melancolico/index.html" />
+    <link rel="canonical" href="/notes/Escritos/Dias%20de%20colores/verde-melancolico/index.html" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #05010a;
+        color: #fce6f6;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 3rem 1.5rem;
+        text-align: center;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), #05010a;
+      }
+      a {
+        color: #ff82c0;
+      }
+      p {
+        max-width: 32rem;
+        line-height: 1.6;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirigiendo a Verde melancólico…</h1>
+      <p>
+        Si no eres redirigido automáticamente, visita
+        <a href="/notes/Escritos/Dias%20de%20colores/verde-melancolico/index.html">la versión actualizada del poema</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -224,7 +224,7 @@
         </p>
         <div class="cta">
           <a href="notes/Escritos/Canciones-poemas-escritos/viewer.html">Abrir visor</a>
-          <a class="secondary" href="notes/Escritos/Canciones-poemas-escritos/">Ir al índice completo</a>
+          <a class="secondary" href="notes/Escritos/Canciones-poemas-escritos/index.html">Ir al índice completo</a>
         </div>
       </div>
     </header>
@@ -245,7 +245,7 @@
               Accede al listado completo de notas exportadas desde Obsidian. Cada enlace te lleva al documento Markdown
               original hospedado en GitHub Pages.
             </p>
-            <a class="more" href="notes/Escritos/Canciones-poemas-escritos/">Ir al índice</a>
+            <a class="more" href="notes/Escritos/Canciones-poemas-escritos/index.html">Ir al índice</a>
           </article>
           <article>
             <h3>Días de colores</h3>
@@ -253,7 +253,7 @@
               Una nueva colección de semillas cromáticas. Cada entrada captura un tono, una sensación y una frase breve
               para inspirar futuros escritos.
             </p>
-            <a class="more" href="notes/Escritos/Dias%20de%20colores/">Ver la paleta</a>
+            <a class="more" href="notes/Escritos/Dias%20de%20colores/index.html">Ver la paleta</a>
 
           </article>
         </section>
@@ -284,6 +284,7 @@ title: Canciones, poemas y escritos
 dg-publish: true
 dg-permalink: /Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/
 ---
+[[Pereza|Pereza]]
 [[Amantes|Amantes]]
 [[Brazos|Brazos]]
 [[Recuerdos|Recuerdos]]
@@ -384,9 +385,10 @@ dg-permalink: /Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/
           listSelector: '#poem-list-root',
           statusSelector: '#status-root',
           hintSelector: '#hint-root',
-          indexPath: 'notes/Escritos/Canciones-poemas-escritos/index.md',
+          indexPath:
+            'notes/Escritos/Canciones-poemas-escritos/Canciones%20poemas%20escritos/index.md',
           viewerBase: 'notes/Escritos/Canciones-poemas-escritos/viewer.html',
-fileBase: 'notes/Escritos/Canciones-poemas-escritos/',
+          fileBase: 'notes/',
 limit: 24,
 fallbackMarkdown: fallbackMarkdown,
 

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/Canciones poemas escritos/index.md
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/Canciones poemas escritos/index.md
@@ -2,6 +2,7 @@
 {"dg-publish":true,"dg-permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","title":"Canciones, poemas y escritos"}
 ---
 
+[[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Pereza\|Pereza]]
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Amantes\|Amantes]]
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Brazos\|Brazos]]
 [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/Recuerdos\|Recuerdos]]

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Índice · Canciones, poemas y escritos</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #05010a;
+        --panel: #12061d;
+        --border: rgba(255, 95, 162, 0.25);
+        --text: #fce6f6;
+        --muted: #d6a9c5;
+        --accent: #ff5fa2;
+        --accent-strong: #ff82c0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), var(--bg);
+        color: var(--text);
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .page {
+        width: min(960px, 100%);
+        margin-inline: auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+
+      nav.breadcrumbs {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        color: var(--muted);
+        font-size: 0.95rem;
+        margin-bottom: 2.25rem;
+      }
+
+      nav.breadcrumbs a {
+        color: var(--muted);
+        text-decoration: none;
+      }
+
+      nav.breadcrumbs a:hover,
+      nav.breadcrumbs a:focus-visible {
+        color: var(--text);
+        text-decoration: underline;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2.2rem, 5vw, 3.1rem);
+        color: var(--accent);
+        letter-spacing: 0.04em;
+      }
+
+      header p {
+        margin: 0.8rem 0 0;
+        color: var(--muted);
+        max-width: 46rem;
+        line-height: 1.7;
+      }
+
+      .actions {
+        margin-top: 1.75rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      .actions a {
+        border-radius: 999px;
+        padding: 0.75rem 1.65rem;
+        border: 1px solid var(--accent);
+        text-decoration: none;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        font-size: 0.85rem;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        background: rgba(255, 95, 162, 0.12);
+        box-shadow: 0 18px 35px rgba(10, 2, 20, 0.45);
+        color: var(--text);
+      }
+
+      .actions a.secondary {
+        background: transparent;
+        border-color: rgba(255, 95, 162, 0.45);
+        box-shadow: none;
+      }
+
+      .actions a:hover,
+      .actions a:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 20px 40px rgba(10, 2, 20, 0.6);
+      }
+
+      section.index {
+        margin-top: 3rem;
+        background: var(--panel);
+        border-radius: 1.5rem;
+        border: 1px solid var(--border);
+        box-shadow: 0 25px 50px rgba(10, 2, 20, 0.55);
+        padding: 2.5rem 2.75rem;
+      }
+
+      section.index h2 {
+        margin-top: 0;
+        color: var(--accent-strong);
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        font-size: 1rem;
+      }
+
+      section.index p[role="status"] {
+        color: var(--muted);
+      }
+
+      ul#poem-list {
+        list-style: none;
+        padding: 0;
+        margin: 1.75rem 0 0;
+        columns: 1;
+        column-gap: 2.5rem;
+      }
+
+      @media (min-width: 56rem) {
+        ul#poem-list {
+          columns: 2;
+        }
+      }
+
+      ul#poem-list li {
+        break-inside: avoid;
+        margin-bottom: 0.45rem;
+      }
+
+      ul#poem-list li a {
+        text-decoration: none;
+        color: inherit;
+        position: relative;
+        display: inline-block;
+        padding-bottom: 0.1rem;
+      }
+
+      ul#poem-list li a::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        height: 0.1rem;
+        background: linear-gradient(90deg, transparent, var(--accent-strong), transparent);
+        transform: scaleX(0);
+        transform-origin: center;
+        transition: transform 0.2s ease;
+      }
+
+      ul#poem-list li a:hover::after,
+      ul#poem-list li a:focus-visible::after {
+        transform: scaleX(1);
+      }
+
+      ul#poem-list li.missing {
+        color: rgba(255, 152, 188, 0.8);
+      }
+
+      ul#poem-list li.missing span {
+        margin-left: 0.35rem;
+        font-size: 0.9em;
+      }
+
+      footer {
+        margin-top: 3.5rem;
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      .muted {
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../../../index.html">← Volver al jardín</a>
+        <span aria-hidden="true">/</span>
+        <span>Canciones, poemas y escritos</span>
+      </nav>
+
+      <header>
+        <h1>Índice completo</h1>
+        <p>
+          Este listado replica el índice exportado desde Obsidian. Cada enlace abre el archivo Markdown original dentro del
+          visor rosa &amp; negro, conservando la ruta exacta del cuaderno digital.
+        </p>
+        <div class="actions">
+          <a href="viewer.html">Abrir visor</a>
+          <a class="secondary" href="Canciones%20poemas%20escritos/index.md">Ver index.md</a>
+        </div>
+      </header>
+
+      <section class="index" aria-labelledby="index-heading">
+        <h2 id="index-heading">Poemas disponibles</h2>
+        <p id="status" role="status">Cargando poemas…</p>
+        <p id="hint" class="muted" hidden>
+          Algunos enlaces están marcados como faltantes porque no se encontró el <code>.md</code> correspondiente dentro de
+          <code>notes/Escritos/Canciones-poemas-escritos/</code>.
+        </p>
+        <ul id="poem-list"></ul>
+        <p class="muted">¿Preferís navegar título por título? Usá el selector del visor para saltar entre poemas.</p>
+      </section>
+
+      <footer>
+        Última comprobación generada en el navegador a partir de <code>Canciones poemas escritos/index.md</code>.
+      </footer>
+    </div>
+
+    <script src="../../../assets/poem-index.js"></script>
+    <script>
+      (function () {
+        if (typeof initPoemIndex !== 'function') {
+          return;
+        }
+
+        initPoemIndex({
+          listSelector: '#poem-list',
+          statusSelector: '#status',
+          hintSelector: '#hint',
+          indexPath: 'Canciones%20poemas%20escritos/index.md',
+          viewerBase: 'viewer.html',
+          fileBase: '../../',
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/viewer.html
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/viewer.html
@@ -272,7 +272,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script>
       (function () {
-        const INDEX_PATH = 'index.md';
+        const INDEX_PATH = encodePathSegments('Canciones poemas escritos/index.md');
         const LINK_RE = /\[\[([^\]|#]+?)(?:\|([^\]]+))?\]\]/g;
         const titleEl = document.getElementById('title');
         const contentEl = document.getElementById('content');
@@ -290,6 +290,39 @@
 
         const isFileProtocol = window.location.protocol === 'file:';
 
+        const viewerDir = window.location.pathname.replace(/[^/]*$/, '');
+        const viewerSegments = viewerDir.split('/').filter(Boolean);
+        const notesIndex = viewerSegments.indexOf('notes');
+        const depthAfterNotes =
+          notesIndex === -1 ? 0 : Math.max(viewerSegments.length - (notesIndex + 1), 0);
+        const notesBasePrefix = depthAfterNotes > 0 ? '../'.repeat(depthAfterNotes) : '';
+
+        const PATH_PROTOCOL_RE = /^(?:[a-z]+:|\/)/i;
+
+        function encodePathSegments(path) {
+          if (!path) return path;
+          return path
+            .split('/')
+            .map((segment) => encodeURIComponent(segment))
+            .join('/');
+        }
+
+        function resolveRequestPath(fileName) {
+          if (!fileName) return fileName;
+          if (
+            PATH_PROTOCOL_RE.test(fileName) ||
+            fileName.startsWith('./') ||
+            fileName.startsWith('../')
+          ) {
+            return encodePathSegments(fileName);
+          }
+          const encoded = encodePathSegments(fileName);
+          if (!notesBasePrefix) {
+            return encoded;
+          }
+          return `${notesBasePrefix}${encoded}`;
+        }
+
         function normalizeFileName(raw) {
           if (!raw) return null;
           let decoded = raw;
@@ -299,6 +332,9 @@
             // Keep raw string if decoding fails
           }
           decoded = decoded.trim();
+          if (decoded.endsWith('\\')) {
+            decoded = decoded.slice(0, -1);
+          }
           if (!decoded) return null;
           return decoded.toLowerCase().endsWith('.md') ? decoded : `${decoded}.md`;
         }
@@ -308,12 +344,20 @@
           return label.replace(/-/g, ' ').trim();
         }
 
+        function cleanLinkTarget(raw) {
+          const value = (raw || '').trim();
+          if (value.endsWith('\\')) {
+            return value.slice(0, -1);
+          }
+          return value;
+        }
+
         function parseIndex(markdown) {
           const items = [];
           if (!markdown) return items;
           let match;
           while ((match = LINK_RE.exec(markdown)) !== null) {
-            const target = (match[1] || '').trim();
+            const target = cleanLinkTarget(match[1]);
             if (!target) continue;
             const label = formatLabel((match[2] || target).trim());
             const baseName = target.replace(/\.md$/i, '');
@@ -417,7 +461,8 @@
           updateControls();
 
           const fileName = item.fileName;
-          fetch(fileName)
+          const requestPath = resolveRequestPath(fileName);
+          fetch(requestPath)
             .then((response) => {
               if (!response.ok) {
                 throw new Error(`No se pudo cargar el archivo (HTTP ${response.status})`);
@@ -436,7 +481,11 @@
             })
             .catch((error) => {
               titleEl.textContent = item.label;
-              renderError(error.message, `Intenté cargar: <code>${fileName}</code>`);
+              const details =
+                requestPath && requestPath !== fileName
+                  ? `Intenté cargar: <code>${requestPath}</code><br />Ruta solicitada: <code>${fileName}</code>`
+                  : `Intenté cargar: <code>${fileName}</code>`;
+              renderError(error.message, details);
               updateDocumentTitle(item.label);
               state.loading = false;
             });

--- a/src/site/notes/Escritos/Dias de colores/Blanco de nuevos comienzos 🤍.md
+++ b/src/site/notes/Escritos/Dias de colores/Blanco de nuevos comienzos 🤍.md
@@ -1,0 +1,10 @@
+---
+{"dg-publish":true,"permalink":"/escritos/dias-de-colores/blanco-de-nuevos-comienzos/","tags":["semillas","color"]}
+---
+
+> [!info] 🌱 Semilla de color
+> <div style="width:100%;height:80px;background:#f4f4f4;border-radius:12px;"></div>
+
+- 🎨 **Código HEX:** `#F4F4F4`
+- 📷 **Imagen:** ![Pasted image 20251001211254.png](/img/user/Pasted%20image%2020251001211254.png)
+- ✍️ **Frase:** "Blanco que guarda la respiración antes del salto."

--- a/src/site/notes/Escritos/Dias de colores/blanco-de-nuevos-comienzos/index.html
+++ b/src/site/notes/Escritos/Dias de colores/blanco-de-nuevos-comienzos/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Blanco de nuevos comienzos 🤍 · Días de colores · Takumi’s Garden</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #05010a;
+        --panel: rgba(255, 255, 255, 0.05);
+        --border: rgba(255, 255, 255, 0.12);
+        --accent: #ff5fa2;
+        --muted: rgba(255, 255, 255, 0.72);
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), var(--bg);
+        color: #fce6f6;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .page {
+        width: min(42rem, 100%);
+        margin-inline: auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+
+      nav.breadcrumbs {
+        margin-bottom: 2rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 0.75rem;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      nav.breadcrumbs a {
+        color: var(--muted);
+        text-decoration: none;
+      }
+
+      nav.breadcrumbs a:hover,
+      nav.breadcrumbs a:focus-visible {
+        color: #fce6f6;
+        text-decoration: underline;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 5vw, 2.8rem);
+        color: var(--accent);
+      }
+
+      .tone-meta {
+        margin: 1rem 0 0;
+        padding: 1.5rem;
+        border-radius: 1.25rem;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .swatch {
+        width: 100%;
+        height: 90px;
+        border-radius: 1rem;
+        background: #f4f4f4;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+      }
+
+      .details {
+        display: grid;
+        gap: 0.65rem;
+        font-size: 0.95rem;
+      }
+
+      .details strong {
+        font-weight: 600;
+      }
+
+      .tone-quote {
+        margin-top: 2rem;
+        font-size: 1.05rem;
+        font-style: italic;
+        line-height: 1.7;
+        color: var(--muted);
+      }
+
+      .tone-quote em {
+        color: #fce6f6;
+        font-style: normal;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../../../../index.html">← Volver al jardín</a>
+        <span aria-hidden="true">/</span>
+        <a href="../index.html">Días de colores</a>
+        <span aria-hidden="true">/</span>
+        <span>Blanco de nuevos comienzos 🤍</span>
+      </nav>
+
+      <header>
+        <h1>Blanco de nuevos comienzos 🤍</h1>
+      </header>
+
+      <section class="tone-meta">
+        <div class="swatch" role="img" aria-label="Muestra de color blanco de nuevos comienzos"></div>
+        <div class="details">
+          <div><strong>🎨 Código HEX:</strong> <code>#F4F4F4</code></div>
+          <div><strong>📷 Imagen:</strong> <a href="../../../../img/user/Pasted%20image%2020251001211254.png">Pasted image 20251001211254.png</a></div>
+        </div>
+      </section>
+
+      <p class="tone-quote">“Blanco que guarda la respiración antes del salto.”</p>
+    </div>
+  </body>
+</html>

--- a/src/site/notes/Escritos/Dias de colores/index.html
+++ b/src/site/notes/Escritos/Dias de colores/index.html
@@ -142,6 +142,12 @@
 
       <main>
         <div class="palette-grid" role="list">
+          <a class="palette-card" href="blanco-de-nuevos-comienzos/" role="listitem">
+            <span class="swatch" style="--tone: #F4F4F4"></span>
+            <span class="tone-name">Blanco de nuevos comienzos 🤍</span>
+            <span class="tone-meta">#F4F4F4</span>
+            <span class="tone-quote">“Blanco que guarda la respiración antes del salto.”</span>
+          </a>
           <a class="palette-card" href="naranja-en-espera/" role="listitem">
             <span class="swatch" style="--tone: #DC7630"></span>
             <span class="tone-name">Naranja en espera 🟧</span>
@@ -158,7 +164,7 @@
       </main>
 
       <footer>
-        Última actualización: 2 tonos publicados.
+        Última actualización: 3 tonos publicados.
       </footer>
     </div>
   </body>

--- a/src/site/notes/Escritos/Dias de colores/index.md
+++ b/src/site/notes/Escritos/Dias de colores/index.md
@@ -62,6 +62,15 @@
 </style>
 
 <div class="palette-grid">
+  <a class="palette-card" href="/escritos/dias-de-colores/blanco-de-nuevos-comienzos/">
+
+    <span class="swatch" style="--tone:#F4F4F4;"></span>
+    <span class="tone-name">Blanco de nuevos comienzos 🤍</span>
+    <span class="tone-meta">#F4F4F4</span>
+    <span class="tone-quote">
+      &ldquo;Blanco que guarda la respiración antes del salto.&rdquo;
+    </span>
+  </a>
   <a class="palette-card" href="/escritos/dias-de-colores/naranja-en-espera/">
 
     <span class="swatch" style="--tone:#DC7630;"></span>


### PR DESCRIPTION
## Summary
- add a redirect page for `/escritos/dias-de-colores/` that forwards visitors to the updated notes index
- create matching redirect stubs for the Naranja en espera and Verde melancólico entries so old links resolve correctly

## Testing
- python3 -m http.server 8000 --directory src/site
- curl -I http://127.0.0.1:8000/escritos/dias-de-colores/index.html
- curl -I http://127.0.0.1:8000/escritos/dias-de-colores/naranja-en-espera/index.html
- curl -I http://127.0.0.1:8000/escritos/dias-de-colores/verde-melancolico/index.html

------
https://chatgpt.com/codex/tasks/task_e_68dd8653159483239c6c2bcce6afe769