### PR TITLE
Add Cositas index note to Obsidian vault

### DIFF
--- a/Cositas/index.md
+++ b/Cositas/index.md
@@ -1,0 +1,7 @@
+Esta carpeta reúne pequeñas listas y colecciones que quiero seguir ampliando.
+
+- [[Cositas/Colecciones|Colecciones]] de objetos que voy juntando.
+- [[Cositas/Generos musicales|Géneros musicales]] y subgéneros por descubrir.
+- [[Cositas/Hobbies|Hobbies]] que tengo pendientes o en curso.
+- [[Cositas/Perfumes|Perfumes]] que me encantan.
+- [[Cositas/Piedras|Piedras]] y cristales con sus propiedades favoritas.

--- a/src/site/notes/Cositas/index.md
+++ b/src/site/notes/Cositas/index.md
@@ -1,0 +1,11 @@
+---
+{"dg-publish": true, "dg-permalink": "/cositas/", "permalink": "/cositas/", "title": "Cositas"}
+---
+
+Esta carpeta reúne pequeñas listas y colecciones que quiero seguir ampliando.
+
+- [[Cositas/Colecciones|Colecciones]] de objetos que voy juntando.
+- [[Cositas/Generos musicales|Géneros musicales]] y subgéneros por descubrir.
+- [[Cositas/Hobbies|Hobbies]] que tengo pendientes o en curso.
+- [[Cositas/Perfumes|Perfumes]] que me encantan.
+- [[Cositas/Piedras|Piedras]] y cristales con sus propiedades favoritas.


### PR DESCRIPTION
## Summary
- add an index page for the Cositas folder in the Obsidian vault so the collection appears in the published garden
- mirror the same overview note in the root Cositas folder for local vault usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7f6e1dac832394bdc12dbed21d51