### PR TITLE
Add Obsidian portfolio entry

### DIFF
--- a/Portfolio.md
+++ b/Portfolio.md
@@ -1,12 +1,12 @@
 # Portfolio
 
-Este cuaderno recoge mis proyectos creativos y apuntes favoritos. Aquí queda un mapa rápido de las áreas que estoy manteniendo en
-Takumi’s Garden y en mi bóveda de Obsidian.
+Este cuaderno recoge mis proyectos creativos y apuntes favoritos. Aquí queda un mapa rápido de las áreas que mantengo en Takumi’s
+Garden y en mi bóveda de Obsidian. Cada enlace apunta a la versión publicada de la nota.
 
 ## 📝 Escritos
-- [[Escritos/Canciones-poemas-escritos/Escritos_indice_con_enlace|Índice de poemas, canciones y escritos]] para navegar todos
-  los textos publicados.
-- La carpeta [[src/site/notes/Escritos/Dias de colores/index|Días de colores]] reúne las semillas cromáticas más recientes.
+- [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/index|Índice de poemas, canciones y escritos]] para navegar
+  todos los textos publicados.
+- [[Escritos/Dias de colores/index|Días de colores]] reúne las semillas cromáticas más recientes.
 
 ## 📦 Cositas
 - [[Cositas/Colecciones|Colecciones]] que voy ampliando con peluches, vinilos y otras piezas que me alegran el día.

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -225,6 +225,7 @@
         <div class="cta">
           <a href="notes/Escritos/Canciones-poemas-escritos/viewer.html">Abrir visor</a>
           <a class="secondary" href="notes/Escritos/Canciones-poemas-escritos/index.html">Ir al índice completo</a>
+          <a class="secondary" href="notes/Portfolio/index.html">Explorar portfolio</a>
         </div>
       </div>
     </header>
@@ -254,7 +255,14 @@
               para inspirar futuros escritos.
             </p>
             <a class="more" href="notes/Escritos/Dias%20de%20colores/index.html">Ver la paleta</a>
-
+          </article>
+          <article>
+            <h3>Portfolio en Obsidian</h3>
+            <p>
+              Un mapa curado de notas con mis proyectos, personajes, colecciones y diarios. La puerta directa a la bóveda
+              publicada desde Obsidian.
+            </p>
+            <a class="more" href="notes/Portfolio/index.html">Recorrer portfolio</a>
           </article>
         </section>
 

--- a/src/site/notes/Portfolio.md
+++ b/src/site/notes/Portfolio.md
@@ -2,8 +2,8 @@
 {"dg-publish":true,"dg-permalink":"/portfolio/","permalink":"/portfolio/","title":"Portfolio"}
 ---
 
-Este cuaderno recoge mis proyectos creativos y apuntes favoritos. Aquí queda un mapa rápido de las áreas que estoy manteniendo en
-Takumi’s Garden y en mi bóveda de Obsidian.
+Este cuaderno recoge mis proyectos creativos y apuntes favoritos. Aquí queda un mapa rápido de las áreas que mantengo en
+Takumi’s Garden y en mi bóveda de Obsidian. Cada enlace apunta a la versión publicada de la nota.
 
 ## 📝 Escritos
 - [[Escritos/Canciones-poemas-escritos/Canciones poemas escritos/index|Índice de poemas, canciones y escritos]] para navegar


### PR DESCRIPTION
## Summary
- add a call-to-action and feature card on the homepage that link to the Obsidian portfolio
- refresh the portfolio note copy so the links point to the published routes in the digital garden

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df7fdfbdac8323a13faf8f81c9aa16