### PR TITLE
Add Cositas index note to Obsidian vault

### DIFF
--- a/Cositas/Colecciones.md
+++ b/Cositas/Colecciones.md
@@ -1,3 +1,7 @@
+---
+{"dg-publish": true, "dg-permalink": "/cositas/colecciones/", "permalink": "/cositas/colecciones/", "title": "Colecciones"}
+---
+
 - Peluches
 - Monsters
 - Inciensos

--- a/Cositas/Generos musicales.md
+++ b/Cositas/Generos musicales.md
@@ -1,4 +1,6 @@
-
+---
+{"dg-publish": true, "dg-permalink": "/cositas/generos-musicales/", "permalink": "/cositas/generos-musicales/", "title": "Géneros musicales"}
+---
 
 1. 🩸 Metal y derivados
 

--- a/Cositas/Hobbies.md
+++ b/Cositas/Hobbies.md
@@ -1,0 +1,4 @@
+---
+{"dg-publish": true, "dg-permalink": "/cositas/hobbies/", "permalink": "/cositas/hobbies/", "title": "Hobbies"}
+---
+

--- a/Cositas/Perfumes.md
+++ b/Cositas/Perfumes.md
@@ -1,3 +1,7 @@
+---
+{"dg-publish": true, "dg-permalink": "/cositas/perfumes/", "permalink": "/cositas/perfumes/", "title": "Perfumes"}
+---
+
 1. velvet orchid
 2. roses musk
 3. alien hypersense

--- a/Cositas/Piedras.md
+++ b/Cositas/Piedras.md
@@ -1,3 +1,6 @@
+---
+{"dg-publish": true, "dg-permalink": "/cositas/piedras/", "permalink": "/cositas/piedras/", "title": "Piedras"}
+---
 
 1. Cuarzo cristalino
 

--- a/Cositas/index.md
+++ b/Cositas/index.md
@@ -1,0 +1,11 @@
+---
+{"dg-publish": true, "dg-permalink": "/cositas/", "permalink": "/cositas/", "title": "Cositas"}
+---
+
+Esta carpeta reúne pequeñas listas y colecciones que quiero seguir ampliando.
+
+- [[Cositas/Colecciones|Colecciones]] de objetos que voy juntando.
+- [[Cositas/Generos musicales|Géneros musicales]] y subgéneros por descubrir.
+- [[Cositas/Hobbies|Hobbies]] que tengo pendientes o en curso.
+- [[Cositas/Perfumes|Perfumes]] que me encantan.
+- [[Cositas/Piedras|Piedras]] y cristales con sus propiedades favoritas.

--- a/src/site/notes/Cositas/index.md
+++ b/src/site/notes/Cositas/index.md
@@ -1,0 +1,11 @@
+---
+{"dg-publish": true, "dg-permalink": "/cositas/", "permalink": "/cositas/", "title": "Cositas"}
+---
+
+Esta carpeta reúne pequeñas listas y colecciones que quiero seguir ampliando.
+
+- [[Cositas/Colecciones|Colecciones]] de objetos que voy juntando.
+- [[Cositas/Generos musicales|Géneros musicales]] y subgéneros por descubrir.
+- [[Cositas/Hobbies|Hobbies]] que tengo pendientes o en curso.
+- [[Cositas/Perfumes|Perfumes]] que me encantan.
+- [[Cositas/Piedras|Piedras]] y cristales con sus propiedades favoritas.


### PR DESCRIPTION
## Summary
- add an index page for the Cositas folder in the Obsidian vault so the collection appears in the published garden
- mirror the same overview note in the root Cositas folder for local vault usage
- restore the digital garden frontmatter on the Cositas notes in the root vault so they show up again inside Obsidian

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7f6e1dac832394bdc12dbed21d51