### PR TITLE
Restore poem index and viewer pages

### DIFF
--- a/src/site/assets/poem-index.js
+++ b/src/site/assets/poem-index.js
@@ -112,13 +112,8 @@
             : fileName;
         const li = document.createElement('li');
         const link = document.createElement('a');
-<<<<<<< HEAD
         const encoded = encodeURIComponent(targetFileName);
         const encodedPath = encodePathSegments(targetFileName);
-=======
-        const encoded = encodeURIComponent(fileName);
-        const encodedPath = encodePathSegments(fileName);
->>>>>>> main
         link.href = `${viewerBase}?file=${encoded}`;
         link.textContent = label;
         li.appendChild(link);

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -291,10 +291,6 @@
 ---
 {"dg-publish":true,"dg-permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","permalink":"/Escritos/Canciones-poemas-escritos/Canciones-poemas-escritos/","title":"Canciones, poemas y escritos"}
 ---
-<<<<<<< HEAD
-=======
-
->>>>>>> main
 [[Pereza|Pereza]]
 [[Amantes|Amantes]]
 [[Brazos|Brazos]]
@@ -401,16 +397,9 @@
             'notes/Escritos/Canciones-poemas-escritos/Canciones%20poemas%20escritos/index.md',
           viewerBase: 'notes/Escritos/Canciones-poemas-escritos/viewer.html',
           fileBase: 'notes/',
-<<<<<<< HEAD
           pathPrefix: 'Escritos/Canciones-poemas-escritos/Canciones poemas escritos/',
           limit: 24,
           fallbackMarkdown: fallbackMarkdown,
-=======
-
-limit: 24,
-fallbackMarkdown: fallbackMarkdown,
-
->>>>>>> main
         });
       })();
     </script>

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Índice completo · Canciones, poemas y escritos</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg-color: #05010a;
+        --panel-color: #12061d;
+        --panel-border: rgba(255, 95, 162, 0.3);
+        --text-color: #fce6f6;
+        --muted-color: #d6a9c5;
+        --accent-color: #ff5fa2;
+        --accent-strong: #ff82c0;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), var(--bg-color);
+        color: var(--text-color);
+      }
+
+      main {
+        width: min(60rem, 100%);
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+
+      header.page-heading {
+        text-align: center;
+        margin-bottom: 2.5rem;
+      }
+
+      header.page-heading p.breadcrumbs {
+        margin: 0 0 1rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        color: var(--muted-color);
+      }
+
+      header.page-heading h1 {
+        margin: 0 0 1rem;
+        color: var(--accent-color);
+      }
+
+      header.page-heading p.lead {
+        margin: 0 auto;
+        max-width: 38rem;
+        line-height: 1.7;
+        color: var(--muted-color);
+      }
+
+      #status-root {
+        margin-top: 1.75rem;
+        color: var(--muted-color);
+      }
+
+      #hint-root {
+        margin-top: 0.75rem;
+        color: rgba(255, 152, 188, 0.85);
+      }
+
+      ul#poem-list-root {
+        list-style: none;
+        padding: 1.75rem;
+        margin: 2.5rem 0 1.5rem;
+        background: var(--panel-color);
+        border-radius: 1.5rem;
+        border: 1px solid var(--panel-border);
+        box-shadow: 0 25px 50px rgba(10, 2, 20, 0.55);
+        columns: 1;
+        column-gap: 2.5rem;
+      }
+
+      @media (min-width: 50rem) {
+        ul#poem-list-root {
+          columns: 2;
+        }
+      }
+
+      ul#poem-list-root li {
+        break-inside: avoid;
+        margin-bottom: 0.5rem;
+      }
+
+      ul#poem-list-root li a {
+        color: var(--text-color);
+        text-decoration: none;
+      }
+
+      ul#poem-list-root li a:hover,
+      ul#poem-list-root li a:focus-visible {
+        color: var(--accent-strong);
+      }
+
+      ul#poem-list-root li.missing {
+        color: rgba(255, 152, 188, 0.85);
+      }
+
+      ul#poem-list-root li.missing span {
+        font-size: 0.9em;
+        margin-left: 0.35rem;
+      }
+
+      footer.page-footer {
+        text-align: center;
+        padding: 0 1.5rem 3rem;
+        color: var(--muted-color);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header class="page-heading">
+        <p class="breadcrumbs">Notas · Canciones, poemas y escritos</p>
+        <h1>Índice completo</h1>
+        <p class="lead">
+          Lista completa de poemas y textos disponibles dentro de la carpeta «Canciones poemas escritos».
+          Selecciona un título para abrirlo en el visor inmersivo.
+        </p>
+        <p id="status-root" role="status">Preparando la lista…</p>
+        <p id="hint-root" hidden>
+          Algunos enlaces aparecen sin archivo porque falta el <code>.md</code> correspondiente. Agrégalo a la carpeta y
+          vuelve a publicar el sitio para resolverlo.
+        </p>
+      </header>
+      <ul id="poem-list-root"></ul>
+    </main>
+    <footer class="page-footer">
+      <a href="../../../../index.html">← Volver al inicio</a>
+    </footer>
+    <noscript>
+      <p role="alert">Activa JavaScript para mostrar el índice completo.</p>
+    </noscript>
+    <script src="../../../assets/poem-index.js"></script>
+    <script>
+      (function () {
+        if (typeof initPoemIndex !== 'function') {
+          return;
+        }
+
+        initPoemIndex({
+          listSelector: '#poem-list-root',
+          statusSelector: '#status-root',
+          hintSelector: '#hint-root',
+          indexPath: 'Canciones poemas escritos/index.md',
+          viewerBase: 'viewer.html',
+          fileBase: '../../',
+          pathPrefix: '',
+          limit: null,
+          fallbackMarkdown: null,
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/src/site/notes/Escritos/Canciones-poemas-escritos/viewer.html
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/viewer.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Visor · Canciones, poemas y escritos</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg-color: #05010a;
+        --panel-color: rgba(20, 6, 35, 0.9);
+        --text-color: #fce6f6;
+        --muted-color: #d6a9c5;
+        --accent-color: #ff5fa2;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Figtree", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at top, rgba(255, 95, 162, 0.12), transparent 55%), var(--bg-color);
+        color: var(--text-color);
+      }
+
+      header.viewer-header {
+        padding: 2.5rem 1.5rem 1rem;
+        text-align: center;
+      }
+
+      header.viewer-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 5vw, 2.85rem);
+        color: var(--accent-color);
+      }
+
+      header.viewer-header p.meta {
+        margin: 0.75rem 0 0;
+        color: var(--muted-color);
+      }
+
+      main {
+        width: min(58rem, 100%);
+        margin: 0 auto;
+        padding: 1rem 1.5rem 4rem;
+      }
+
+      article.poem {
+        background: var(--panel-color);
+        border-radius: 1.75rem;
+        border: 1px solid rgba(255, 95, 162, 0.3);
+        padding: clamp(1.5rem, 3vw, 3rem);
+        box-shadow: 0 35px 60px rgba(10, 2, 20, 0.65);
+      }
+
+      #status-root {
+        text-align: center;
+        margin: 0 auto 1.5rem;
+        color: var(--muted-color);
+      }
+
+      .poem-content h1,
+      .poem-content h2,
+      .poem-content h3,
+      .poem-content h4,
+      .poem-content h5,
+      .poem-content h6 {
+        color: var(--accent-color);
+      }
+
+      .poem-content p,
+      .poem-content li {
+        line-height: 1.75;
+      }
+
+      .poem-content pre {
+        background: rgba(255, 95, 162, 0.12);
+        padding: 1rem;
+        border-radius: 1rem;
+        overflow-x: auto;
+      }
+
+      footer.viewer-footer {
+        text-align: center;
+        padding: 0 1.5rem 3rem;
+        color: var(--muted-color);
+      }
+
+      footer.viewer-footer a {
+        color: var(--accent-color);
+      }
+
+      .button-row {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        margin-top: 1.5rem;
+        flex-wrap: wrap;
+      }
+
+      .button-row a {
+        border-radius: 999px;
+        border: 1px solid rgba(255, 95, 162, 0.45);
+        padding: 0.65rem 1.5rem;
+        text-decoration: none;
+        color: var(--text-color);
+      }
+
+      .button-row a:hover,
+      .button-row a:focus-visible {
+        color: var(--accent-color);
+        border-color: var(--accent-color);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="viewer-header">
+      <h1 id="poem-title">Visor de poemas</h1>
+      <p class="meta" id="status-root" role="status">Selecciona un poema desde el índice para cargarlo aquí.</p>
+      <div class="button-row">
+        <a href="index.html">Abrir índice completo</a>
+        <a href="../../../../index.html">Volver al inicio</a>
+        <a id="raw-link" href="#" download>Descargar .md</a>
+      </div>
+    </header>
+    <main>
+      <article class="poem">
+        <div id="poem-content" class="poem-content"></div>
+      </article>
+    </main>
+    <footer class="viewer-footer">
+      <p>
+        Los textos se cargan directamente desde los archivos Markdown publicados en esta carpeta.
+      </p>
+    </footer>
+    <noscript>
+      <p role="alert" class="viewer-footer">Activa JavaScript para mostrar el contenido del poema.</p>
+    </noscript>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>
+      (function () {
+        if (typeof window === 'undefined') {
+          return;
+        }
+
+        const params = new URLSearchParams(window.location.search);
+        const fileParam = params.get('file');
+        const statusEl = document.getElementById('status-root');
+        const titleEl = document.getElementById('poem-title');
+        const contentEl = document.getElementById('poem-content');
+        const rawLink = document.getElementById('raw-link');
+
+        function setStatus(text, isError) {
+          if (!statusEl) return;
+          statusEl.textContent = text;
+          statusEl.style.color = isError ? 'rgba(255, 152, 188, 0.9)' : 'var(--muted-color)';
+        }
+
+        function sanitizePath(value) {
+          if (!value) return '';
+          let decoded;
+          try {
+            decoded = decodeURIComponent(value);
+          } catch (error) {
+            return '';
+          }
+          decoded = decoded.replace(/\\+/g, '/').replace(/^\/+/, '');
+          if (decoded.includes('..')) {
+            return '';
+          }
+          return decoded;
+        }
+
+        function resolveFetchPath(path) {
+          if (!path) return null;
+          if (path.startsWith('Escritos/')) {
+            return `../../${path}`;
+          }
+          if (path.startsWith('Portfolio/')) {
+            return `../../${path}`;
+          }
+          return path;
+        }
+
+        function updateTitleFromPath(path) {
+          if (!path) return;
+          const parts = path.split('/');
+          const fileName = parts[parts.length - 1] || '';
+          const clean = fileName.replace(/\.md$/i, '');
+          if (clean) {
+            document.title = `${clean} · Visor`;
+            titleEl.textContent = clean;
+          }
+        }
+
+        function setRawLink(path, fetchPath) {
+          if (!rawLink) return;
+          if (!path || !fetchPath) {
+            rawLink.setAttribute('aria-disabled', 'true');
+            rawLink.removeAttribute('href');
+            return;
+          }
+          rawLink.removeAttribute('aria-disabled');
+          rawLink.href = fetchPath;
+          const fileName = path.split('/').pop() || 'poema.md';
+          rawLink.download = fileName;
+        }
+
+        if (!fileParam) {
+          setRawLink(null, null);
+          return;
+        }
+
+        const sanitizedPath = sanitizePath(fileParam);
+        if (!sanitizedPath) {
+          setStatus('No se pudo interpretar el archivo solicitado.', true);
+          setRawLink(null, null);
+          return;
+        }
+
+        const fetchPath = resolveFetchPath(sanitizedPath);
+        if (!fetchPath) {
+          setStatus('Ruta del archivo inválida.', true);
+          setRawLink(null, null);
+          return;
+        }
+
+        updateTitleFromPath(sanitizedPath);
+        setRawLink(sanitizedPath, fetchPath);
+        setStatus('Cargando poema…');
+
+        fetch(fetchPath)
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}`);
+            }
+            return response.text();
+          })
+          .then((markdown) => {
+            const html = window.marked ? window.marked.parse(markdown) : markdown;
+            contentEl.innerHTML = html;
+            setStatus('Poema cargado.');
+          })
+          .catch((error) => {
+            console.error(error);
+            contentEl.innerHTML = '';
+            setStatus('No se pudo cargar el poema solicitado.', true);
+            setRawLink(null, null);
+          });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- remove the leftover merge-conflict markers from the home page and restore the poem index configuration
- ensure the poem index script encodes URLs with the correct directory prefix before checking for missing files
- add dedicated index and viewer pages under notes/Escritos/Canciones-poemas-escritos with styling, navigation links, and markdown rendering

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e65c9220788323b502a39b825d1740