### PR TITLE
Fix viewer paths for poems

### DIFF
--- a/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
+++ b/src/site/notes/Escritos/Canciones-poemas-escritos/index.html
@@ -152,7 +152,7 @@
           indexPath: 'Canciones poemas escritos/index.md',
           viewerBase: 'viewer.html',
           fileBase: '../../',
-          pathPrefix: '',
+          pathPrefix: 'Escritos/Canciones-poemas-escritos/Canciones poemas escritos/',
           limit: null,
           fallbackMarkdown: null,
         });


### PR DESCRIPTION
## Summary
- ensure the full poem index passes the proper path prefix when building viewer links
- allow the immersive viewer to fetch markdown files from the correct folder

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e6a5b244688323b54ac592129e3a89